### PR TITLE
Update file_export.ts

### DIFF
--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 declare var window: any;
 
 export function exportSeriesListToCsv(seriesList) {
-    var text = 'Series;Time;Value\n';
+    var text = 'sep=;\nSeries;Time;Value\n';
     _.each(seriesList, function(series) {
         _.each(series.datapoints, function(dp) {
             text += series.alias + ';' + new Date(dp[1]).toISOString() + ';' + dp[0] + '\n';
@@ -15,7 +15,7 @@ export function exportSeriesListToCsv(seriesList) {
 };
 
 export function exportSeriesListToCsvColumns(seriesList) {
-    var text = 'Time;';
+    var text = 'sep=;\nTime;';
     // add header
     _.each(seriesList, function(series) {
         text += series.alias + ';';


### PR DESCRIPTION
resolves #2401

Prepended first line to export file containing
`sep=;\n`
which I believe should be all that is required for Excel to interpret the CSV file as semicolon delimited. I have verified the changed output file would be correct, but not that this is the only change required to produce that output file, so needs verification by someone more familiar with the code than me.
